### PR TITLE
Make cryodrgn analyze produce a plot of the learning curve, fix #304

### DIFF
--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -100,7 +100,7 @@ def analyze_z1(z, outdir, vg):
     vg.gen_volumes(outdir, ztraj)
 
 
-def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
+def analyze_zN(z, outdir, vg, workdir, epoch, skip_umap=False, num_pcs=2, num_ksamples=20):
     zdim = z.shape[1]
 
     # Principal component analysis
@@ -134,6 +134,17 @@ def analyze_zN(z, outdir, vg, skip_umap=False, num_pcs=2, num_ksamples=20):
 
     # Make some plots
     logger.info("Generating plots...")
+
+    # Plot learning curve
+    loss = analysis.parse_loss(f"{workdir}/run.log")
+    plt.figure(figsize=(4, 4))
+    plt.plot(loss)
+    plt.xlabel("Epoch")
+    plt.ylabel("Loss")
+    plt.axvline(x=epoch, linestyle="--", color="black", label=f"Epoch {epoch}")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(f"{outdir}/learning_curve_epoch{epoch}.png")
 
     def plt_pc_labels(x=0, y=1):
         plt.xlabel(f"PC{x+1} ({pca.explained_variance_ratio_[x]:.2f})")
@@ -352,6 +363,7 @@ def main(args):
     t1 = dt.now()
     E = args.epoch
     workdir = args.workdir
+    epoch = args.epoch
     zfile = f"{workdir}/z.{E}.pkl"
     weights = f"{workdir}/weights.{E}.pkl"
     cfg = (
@@ -391,6 +403,8 @@ def main(args):
             z,
             outdir,
             vg,
+            workdir,
+            epoch,
             skip_umap=args.skip_umap,
             num_pcs=args.pc,
             num_ksamples=args.ksample,

--- a/cryodrgn/templates/cryoDRGN_ET_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_ET_viz_template.ipynb
@@ -254,8 +254,10 @@
    "source": [
     "loss = analysis.parse_loss(f'{WORKDIR}/run.log')\n",
     "plt.plot(loss)\n",
-    "plt.xlabel('epoch')\n",
-    "plt.ylabel('loss')"
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.legend()"
    ]
   },
   {

--- a/cryodrgn/templates/cryoDRGN_ET_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_ET_viz_template.ipynb
@@ -256,7 +256,7 @@
     "plt.plot(loss)\n",
     "plt.xlabel(\"Epoch\")\n",
     "plt.ylabel(\"Loss\")\n",
-    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.axvline(x=EPOCH, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
     "plt.legend()"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_figures_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_figures_template.ipynb
@@ -59,6 +59,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "83324d44-767e-47e2-a3c7-cab9b430fab5",
+   "metadata": {},
+   "source": [
+    "# Plot learning curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6ba1e22-696c-4c46-a2de-48c386ef8526",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = analysis.parse_loss(f'{WORKDIR}/run.log')\n",
+    "plt.figure(figsize=(4, 4))\n",
+    "plt.plot(loss)\n",
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "#plt.savefig(f\"{WORKDIR}/analyze.{EPOCH}/learning_curve_epoch{EPOCH}.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9cce7848",
    "metadata": {},
    "source": [

--- a/cryodrgn/templates/cryoDRGN_figures_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_figures_template.ipynb
@@ -77,7 +77,7 @@
     "plt.plot(loss)\n",
     "plt.xlabel(\"Epoch\")\n",
     "plt.ylabel(\"Loss\")\n",
-    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.axvline(x=EPOCH, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
     "plt.legend()\n",
     "plt.tight_layout()\n",
     "#plt.savefig(f\"{WORKDIR}/analyze.{EPOCH}/learning_curve_epoch{EPOCH}.png\")"

--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -317,8 +317,10 @@
    "source": [
     "loss = analysis.parse_loss(f'{WORKDIR}/run.log')\n",
     "plt.plot(loss)\n",
-    "plt.xlabel('epoch')\n",
-    "plt.ylabel('loss')"
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.legend()"
    ]
   },
   {

--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -319,7 +319,7 @@
     "plt.plot(loss)\n",
     "plt.xlabel(\"Epoch\")\n",
     "plt.ylabel(\"Loss\")\n",
-    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.axvline(x=EPOCH, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
     "plt.legend()"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_viz_template.ipynb
@@ -238,7 +238,7 @@
     "plt.plot(loss)\n",
     "plt.xlabel(\"Epoch\")\n",
     "plt.ylabel(\"Loss\")\n",
-    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.axvline(x=EPOCH, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
     "plt.legend()"
    ]
   },

--- a/cryodrgn/templates/cryoDRGN_viz_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_viz_template.ipynb
@@ -236,8 +236,10 @@
    "source": [
     "loss = analysis.parse_loss(f'{WORKDIR}/run.log')\n",
     "plt.plot(loss)\n",
-    "plt.xlabel('epoch')\n",
-    "plt.ylabel('loss')"
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.axvline(x=epoch, linestyle=\"--\", color=\"black\", label=f\"Epoch {EPOCH}\")\n",
+    "plt.legend()"
    ]
   },
   {


### PR DESCRIPTION
Hello,

Here is an addition to `cryodrgn analyze`: it now writes a PNG file with a plot of the learning curve. This addresses #304.
The resulting plot is not super pretty, but its main goal is to make users think about convergence without having to run the Jupyter notebook.

![learning_curve_epoch29](https://github.com/ml-struct-bio/cryodrgn/assets/9656546/41b36b72-4ea7-492b-a775-bba7169fe15b)

I hope this will be helpful.