### PR TITLE
v3.1.0-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+.idea/
 lib/
 lib64/
 parts/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The official [cryoDRGN-ET](https://www.biorxiv.org/content/10.1101/2023.08.18.55
 * Updated `cryodrgn backproject_voxel` for voxel-based homogeneous reconstruction
 * Major refactor of dataset loading for handling large datasets
 
+### New in Version 3.1.x ###
+
+* [NEW] `drgnai filter` interface for interactive filtering of particles as an alternative to the cryoDRGN_filter Jupyter notebook
+
 ### Previous versions
 
 <details><summary>Version 2.3</summary>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For any feedback, questions, or bugs, please file a Github issue, start a Github
 
 ## New in Version 3.x
 
-The official [cryoDRGN-ET](https://www.biorxiv.org/content/10.1101/2023.08.18.553799v1) release for heterogeneous subtomogram analysis. 
+The official [cryoDRGN-ET](https://www.biorxiv.org/content/10.1101/2023.08.18.553799v1) release for heterogeneous subtomogram analysis.
 
 * [NEW] Heterogeneous reconstruction of subtomograms. See documentation [on gitbook](https://ez-lab.gitbook.io/cryodrgn/)
 * [NEW] `cryodrgn direct_traversal` for making movies
@@ -22,7 +22,7 @@ The official [cryoDRGN-ET](https://www.biorxiv.org/content/10.1101/2023.08.18.55
 ### Previous versions
 
 <details><summary>Version 2.3</summary>
-	
+
 * Model configuration files are now saved as human-readable config.yaml files (https://github.com/zhonge/cryodrgn/issues/235)
 * Fix machine stamp in output .mrc files for better compatibility with downstream tools (https://github.com/zhonge/cryodrgn/pull/260)
 * Better documentation of help flags in ab initio reconstruction tools (https://github.com/zhonge/cryodrgn/issues/258)
@@ -490,6 +490,9 @@ Notes:
 [1] Volumes are generated after k-means clustering of the latent embeddings with k=20 by default. Note that we use k-means clustering here not to identify clusters, but to segment the latent space and generate structures from different regions of the latent space. The number of structures that are generated may be increased with the option `--ksample`.
 
 [2] The `cryodrgn analyze` command chains together a series of calls to `cryodrgn eval_vol` and other scripts that can be run separately for more flexibility. These scripts are located in the `analysis_scripts` directory within the source code.
+
+[3] In particular, you may find it useful to perform filtering of particles separately from other analyses. This can
+done using our interactive interface available from the command line: `cryodrgn filter 01_cryodrgn256`.
 
 ### Generating additional volumes
 

--- a/cryodrgn/__main__.py
+++ b/cryodrgn/__main__.py
@@ -21,6 +21,7 @@ def main():
     import cryodrgn.commands.downsample
     import cryodrgn.commands.eval_images
     import cryodrgn.commands.eval_vol
+    import cryodrgn.commands.filter
     import cryodrgn.commands.graph_traversal
     import cryodrgn.commands.parse_ctf_csparc
     import cryodrgn.commands.parse_ctf_star
@@ -44,6 +45,7 @@ def main():
         cryodrgn.commands.backproject_voxel,
         cryodrgn.commands.train_vae,
         cryodrgn.commands.eval_vol,
+        cryodrgn.commands.filter,
         cryodrgn.commands.eval_images,
         cryodrgn.commands.analyze,
         cryodrgn.commands.analyze_landscape,

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -327,7 +327,7 @@ def analyze_zN(
 
         if i > 0 and i == num_pcs - 1:
             g = sns.jointplot(
-                pc[:, i - 1], pc[:, i], alpha=0.1, s=1, rasterized=True, height=4
+                x=pc[:, i - 1], y=pc[:, i], alpha=0.1, s=1, rasterized=True, height=4
             )
             g.ax_joint.scatter(np.zeros(10), t, c="cornflowerblue", edgecolor="white")
             plt_pc_labels_jointplot(g, i - 1, i)

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -42,7 +42,7 @@ def add_args(parser):
     group.add_argument(
         "--Apix",
         type=float,
-        help="Pixel size to add to .mrc header (default is to use A/px found in ctf)",
+        help="Pixel size to add to .mrc header (default is to infer from ctf.pkl file else 1)",
     )
     group.add_argument(
         "--flip", action="store_true", help="Flip handedness of output volumes"

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -386,6 +386,7 @@ def main(args):
             ctf_params = utils.load_pkl(configs["dataset_args"]["ctf"])
             orig_apixs = set(ctf_params[:, 1])
 
+	    # TODO: add support for multiple optics groups
             if len(orig_apixs) > 1:
                 use_apix = 1.0
                 logger.info(

--- a/cryodrgn/commands/analyze_landscape.py
+++ b/cryodrgn/commands/analyze_landscape.py
@@ -380,9 +380,9 @@ def analyze_volumes(
     def hack_barplot(counts_):
         if M <= 20:  # HACK TO GET COLORS
             with sns.color_palette(cmap):
-                g = sns.barplot(np.arange(M), counts_)
+                g = sns.barplot(x=np.arange(M), y=counts_)
         else:  # default is husl
-            g = sns.barplot(np.arange(M), counts_)
+            g = sns.barplot(x=np.arange(M), y=counts_)
         return g
 
     plt.figure()

--- a/cryodrgn/commands/backproject_voxel.py
+++ b/cryodrgn/commands/backproject_voxel.py
@@ -50,59 +50,69 @@ def add_args(parser):
         "`cryodrgn_utils regularize_backproject`.",
     )
 
-    group = parser.add_argument_group("Dataset loading options")
-    group.add_argument(
+    dataset_group = parser.add_argument_group("Dataset loading options")
+    dataset_group.add_argument(
         "--uninvert-data",
         dest="invert_data",
         action="store_false",
         help="Do not invert data sign",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "--datadir",
         type=os.path.abspath,
         help="Path prefix to particle stack if loading relative paths from a .star or .cs file",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "--lazy",
         action="store_true",
         help="Lazy loading if full dataset is too large to fit in memory",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "--ind",
         type=os.path.abspath,
         metavar="PKL",
         help="Filter particles by these indices",
     )
-    group.add_argument(
-        "--first",
-        type=int,
-        default=None,
-        help="Backproject the first N images (default: all images)",
-    )
-    group = parser.add_argument_group("Tilt series options")
-    group.add_argument(
+    dataset_group = parser.add_argument_group("Tilt series options")
+    dataset_group.add_argument(
         "--tilt",
         action="store_true",
         help="Flag to treat data as a tilt series from cryo-ET",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "--ntilts",
         type=int,
         default=10,
         help="Number of tilts per particle to backproject (default: %(default)s)",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "-d",
         "--dose-per-tilt",
         type=float,
         help="Expected dose per tilt (electrons/A^2 per tilt) (default: %(default)s)",
     )
-    group.add_argument(
+    dataset_group.add_argument(
         "-a",
         "--angle-per-tilt",
         type=float,
         default=3,
         help="Tilt angle increment per tilt in degrees (default: %(default)s)",
+    )
+
+    imgs_group = parser.add_mutually_exclusive_group()
+    imgs_group.add_argument(
+        "--first",
+        type=int,
+        default=None,
+        help="Backproject the first N images (default: all images)",
+    )
+
+    imgs_group.add_argument(
+        "--half-map",
+        type=int,
+        nargs="?",
+        const=np.random.randint(10000),
+        help="Generate a half map using the given random seed; chooses a random seed for you if none given.",
     )
 
     return parser
@@ -212,34 +222,41 @@ def main(args):
     mask = lattice.get_circular_mask(D // 2)
 
     if args.first:
-        args.first = min(args.first, Nimg)
-        iterator = range(args.first)
+        iterator = range(min(args.first, Nimg))
+
+    elif args.half_map:
+        np.random.seed(args.half_map)
+        iterator = np.random.choice(range(Nimg), Nimg // 2, replace=False)
+
     else:
         iterator = range(Nimg)
 
-    for ii in iterator:
-        if ii % 100 == 0:
-            logger.info("image {}".format(ii))
-        r, t = posetracker.get_pose(ii)
-        ff = data.get_tilt(ii) if args.tilt else data[ii]
+    for i, j in enumerate(iterator):
+        if i % 100 == 0:
+            logger.info("image {}".format(i))
+
+        r, t = posetracker.get_pose(j)
+        ff = data.get_tilt(j) if args.tilt else data[j]
         assert isinstance(ff, tuple)
 
         ff = ff[0].to(device)
         ff = ff.view(-1)[mask]
-        c = None
         ctf_mul = 1
+
         if ctf_params is not None:
-            freqs = lattice.freqs2d / ctf_params[ii, 0]
-            c = ctf.compute_ctf(freqs, *ctf_params[ii, 1:]).view(-1)[mask]
+            freqs = lattice.freqs2d / ctf_params[j, 0]
+            c = ctf.compute_ctf(freqs, *ctf_params[j, 1:]).view(-1)[mask]
             if args.ctf_alg == "flip":
                 ff *= c.sign()
             else:
                 ctf_mul = c
+
         if t is not None:
             ff = lattice.translate_ht(ff.view(1, -1), t.view(1, 1, 2), mask).view(-1)
+
         if args.tilt:
-            tilt_idxs = torch.tensor([ii]).to(device)
-            dose_filters = data.get_dose_filters(tilt_idxs, lattice, ctf_params[ii, 0])[
+            tilt_idxs = torch.tensor([j]).to(device)
+            dose_filters = data.get_dose_filters(tilt_idxs, lattice, ctf_params[j, 0])[
                 0
             ]
             ctf_mul *= dose_filters[mask]

--- a/cryodrgn/commands/filter.py
+++ b/cryodrgn/commands/filter.py
@@ -1,0 +1,374 @@
+"""Interactive filtering of mapped particles."""
+
+import os
+import pickle
+import argparse
+
+import pandas as pd
+import yaml
+import re
+import numpy as np
+import logging
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+from matplotlib import colors
+from matplotlib.backend_bases import Event, MouseButton
+from matplotlib.widgets import LassoSelector, RadioButtons
+from matplotlib.path import Path as PlotPath
+from scipy.spatial.transform import Rotation as RR
+
+from cryodrgn import analysis
+from cryodrgn import utils
+
+logger = logging.getLogger(__name__)
+
+
+def add_args(parser):
+    parser.add_argument(
+        "outdir", type=os.path.abspath, help="experiment output directory"
+    )
+
+    parser.add_argument(
+        "--epoch",
+        "-e",
+        type=int,
+        default=-1,
+        help="which train epoch to use for filtering",
+    )
+    parser.add_argument(
+        "--kmeans",
+        "-k",
+        type=int,
+        default=-1,
+        help="which set of k-means clusters " "to use for filtering",
+    )
+
+    parser.add_argument(
+        "--inds",
+        type=str,
+        help="Path to a file containing previously " "selected indices.",
+    )
+
+
+def main(args) -> None:
+    workdir = args.outdir
+    epoch = args.epoch
+    kmeans = args.kmeans
+    pre_inds = args.inds
+
+    train_configs_file = os.path.join(workdir, "config.yaml")
+    if not os.path.exists(train_configs_file):
+        raise ValueError("Missing config.yaml file " "in given output folder!")
+
+    conf_fls = [fl for fl in os.listdir(workdir) if re.fullmatch(r"z\.[0-9]+\.pkl", fl)]
+
+    if not conf_fls:
+        raise NotImplementedError(
+            "Filtering is not available for the output "
+            "of homogeneous reconstruction!"
+        )
+
+    with open(train_configs_file, "r") as f:
+        train_configs = yaml.safe_load(f)
+
+    if epoch == -1:
+        epoch = max(int(x.split(".")[1]) for x in conf_fls)
+        logger.info(f"Using epoch {epoch} for filtering...")
+
+    anlzdir = os.path.join(workdir, f"analyze.{epoch}")
+    z = utils.load_pkl(os.path.join(workdir, f"z.{epoch}.pkl"))
+
+    # load poses
+    if train_configs["dataset_args"]["do_pose_sgd"]:
+        pose_pkl = os.path.join(workdir, f"pose.{epoch}.pkl")
+
+        with open(pose_pkl, "rb") as f:
+            rot, trans = pickle.load(f)
+
+    else:
+        pose_pkl = train_configs["dataset_args"]["poses"]
+        rot, trans = utils.load_pkl(pose_pkl)
+
+    ctf_params = utils.load_pkl(train_configs["dataset_args"]["ctf"])
+    if isinstance(train_configs["dataset_args"]["ind"], int):
+        ctf_params = ctf_params[: train_configs["dataset_args"]["ind"]]
+
+    pc, pca = analysis.run_pca(z)
+    umap = utils.load_pkl(os.path.join(anlzdir, "umap.pkl"))
+
+    # load preselected indices if they have been specified
+    if pre_inds:
+        with open(pre_inds, "rb") as file:
+            pre_indices = pickle.load(file)
+    else:
+        pre_indices = None
+
+    if kmeans == -1:
+        kmeans_dirs = [
+            d
+            for d in os.listdir(anlzdir)
+            if os.path.isdir(os.path.join(anlzdir, d))
+            and re.match(r"^kmeans[0-9]+$", d)
+        ]
+
+        if len(kmeans_dirs) == 0:
+            raise RuntimeError(
+                "Did not find any k-means clustering result "
+                "outputs for this experiment!"
+            )
+
+        kmeans_dir = os.path.join(anlzdir, kmeans_dirs[0])
+        if len(kmeans_dirs) > 1:
+            print(
+                "Found more than one set of k-means results but no "
+                "particular k-means set specified, "
+                f"defaulting to {kmeans_dir}"
+            )
+
+    else:
+        kmeans_dir = os.path.join(anlzdir, f"kmeans{kmeans}")
+
+        if not os.path.exists(kmeans_dir):
+            raise ValueError(
+                "This experiment does not contain results for "
+                f"k-means clustering using k={kmeans}!"
+            )
+
+    kmeans_lbls = utils.load_pkl(os.path.join(kmeans_dir, "labels.pkl"))
+
+    plot_df = analysis.load_dataframe(
+        z=z,
+        pc=pc,
+        euler=RR.from_matrix(rot).as_euler("zyz", degrees=True),
+        trans=trans,
+        labels=kmeans_lbls,
+        umap=umap,
+        df1=ctf_params[:, 2],
+        df2=ctf_params[:, 3],
+        dfang=ctf_params[:, 4],
+        phase=ctf_params[:, 8],
+        znorm=np.sum(z**2, axis=1) ** 0.5,
+    )
+
+    selector = SelectFromScatter(plot_df, pre_indices)
+    input("Press Enter after making your selection...")
+    selected_indices = selector.indices if pre_indices is None else pre_indices
+    plt.close()  # Close the figure to avoid interference with other plots
+
+    print(f"Selected particles: {selected_indices}")
+    save_option = (
+        input("Do you want to save the " "selection? (yes/no): ").strip().lower()
+    )
+
+    if save_option == "yes":
+        filename = input(
+            "Enter filename to save selection (absolute, " "without extension): "
+        ).strip()
+
+        # saving the selected indices
+        if filename:
+            selected_full_path = filename + ".pkl"
+
+            with open(selected_full_path, "wb") as file:
+                pickle.dump(selected_indices, file)
+            print(f"Selection saved to {selected_full_path}")
+
+            # Saving the inverse selection
+            inverse_filename = filename + "_inverse.pkl"
+            inverse_indices = np.setdiff1d(np.arange(umap.shape[0]), selected_indices)
+
+            with open(inverse_filename, "wb") as file:
+                pickle.dump(inverse_indices, file)
+
+            print(f"Inverse selection saved to {inverse_filename}")
+
+
+class SelectFromScatter:
+    def __init__(self, data_table: pd.DataFrame, pre_indices: list[int]) -> None:
+        self.data_table = data_table
+        self.scatter = None
+
+        self.fig = plt.figure(constrained_layout=True)
+        gs = self.fig.add_gridspec(2, 3, width_ratios=[1, 7, 1])
+        self.main_ax = self.fig.add_subplot(gs[:, 1])
+
+        self.select_cols = [
+            col for col in data_table.select_dtypes("number").columns if col != "index"
+        ]
+
+        self.xcol, self.ycol = "UMAP1", "UMAP2"
+        self.color_col = "None"
+        self.pnt_colors = None
+
+        lax = self.fig.add_subplot(gs[0, 0])
+        lax.axis("off")
+        lax.set_title("choose\nx-axis", size=13)
+        self.menu_x = RadioButtons(lax, labels=self.select_cols, active=0)
+        self.menu_x.on_clicked(self.choose_xaxis)
+
+        rax = self.fig.add_subplot(gs[1, 0])
+        rax.axis("off")
+        rax.set_title("choose\ny-axis", size=13)
+        self.menu_y = RadioButtons(rax, labels=self.select_cols, active=1)
+        self.menu_y.on_clicked(self.choose_yaxis)
+
+        cax = self.fig.add_subplot(gs[:, 2])
+        cax.axis("off")
+        cax.set_title("choose\ncolors", size=13)
+        self.menu_col = RadioButtons(cax, labels=["None"] + self.select_cols, active=0)
+        self.menu_col.on_clicked(self.choose_colors)
+
+        self.lasso = LassoSelector(self.main_ax, onselect=self.choose_points)
+        self.indices = pre_indices if pre_indices else list()
+        self.annot = None
+        self.pik_txt = None
+
+        self.handl_id = self.fig.canvas.mpl_connect(
+            "motion_notify_event", self.hover_points
+        )
+        self.fig.canvas.mpl_connect("button_press_event", self.on_click)
+        self.fig.canvas.mpl_connect("button_release_event", self.on_release)
+
+        self.plot()
+
+    def plot(self) -> None:
+        self.main_ax.clear()
+        pnt_colors = ["gray" for _ in range(self.data_table.shape[0])]
+
+        if len(self.indices):
+            for idx in self.indices:
+                pnt_colors[idx] = "goldenrod"
+
+        elif self.color_col != "None":
+            clr_vals = self.data_table[self.color_col]
+
+            if clr_vals.dtype == np.int64:
+                use_cmap = sns.color_palette("tab10", as_cmap=True)
+
+                def use_norm(x):
+                    return x
+
+            elif clr_vals.min() < 0 and clr_vals.max() > 0:
+                use_max = max(abs(clr_vals))
+                use_norm = colors.Normalize(vmin=-use_max, vmax=use_max)
+                use_cmap = sns.color_palette("Spectral", as_cmap=True)
+
+            elif clr_vals.max() < 0:
+                use_norm = colors.Normalize(vmin=clr_vals.min(), vmax=0)
+                use_cmap = sns.color_palette("ch:s=1.25,rot=-.7", as_cmap=True)
+            else:
+                use_norm = colors.Normalize(vmin=0, vmax=clr_vals.max())
+                use_cmap = sns.color_palette("ch:s=0.25,rot=-.7", as_cmap=True)
+
+            pnt_colors = use_cmap(use_norm(self.data_table[self.color_col]))
+
+        self.scatter = self.main_ax.scatter(
+            x=self.data_table[self.xcol],
+            y=self.data_table[self.ycol],
+            s=1,
+            alpha=0.5,
+            color=pnt_colors,
+        )
+
+        self.main_ax.set_xlabel(self.xcol, size=17, weight="semibold")
+        self.main_ax.set_ylabel(self.ycol, size=17, weight="semibold")
+        self.main_ax.set_title("Select Points Manually", size=23, weight="semibold")
+
+        self.annot = self.main_ax.annotate(
+            "",
+            xy=(0, 0),
+            xytext=(20, 20),
+            textcoords="offset points",
+            bbox=dict(boxstyle="round", fc="w"),
+            arrowprops=dict(arrowstyle="->"),
+            annotation_clip=False,
+        )
+        self.annot.set_visible(False)
+
+        self.pik_txt = self.main_ax.text(
+            0.99,
+            0.01,
+            f"# of selected particles: {len(self.indices)}",
+            size=11,
+            fontstyle="italic",
+            ha="right",
+            va="bottom",
+            transform=self.main_ax.transAxes,
+        )
+
+        plt.show(block=False)
+        plt.draw()
+
+    def choose_xaxis(self, xlbl: str) -> None:
+        self.xcol = xlbl
+        self.plot()
+
+    def choose_yaxis(self, ylbl: str) -> None:
+        self.ycol = ylbl
+        self.plot()
+
+    def choose_colors(self, colors: str) -> None:
+        self.color_col = colors
+
+        if self.color_col != "None":
+            self.indices = list()
+
+        self.plot()
+
+    def choose_points(self, verts: np.array) -> None:
+        self.indices = np.where(
+            PlotPath(verts).contains_points(self.scatter.get_offsets())
+        )[0]
+
+        self.color_col = "None"
+        self.menu_col.set_active(0)
+        self.plot()
+
+    def hover_points(self, event: Event):
+        vis = self.annot.get_visible()
+
+        if event.inaxes == self.main_ax:
+            cont, ix = self.scatter.contains(event)
+
+            if cont:
+                pos = self.scatter.get_offsets()[ix["ind"][0]]
+
+                self.annot.xy = pos
+                ant_lbls = [
+                    str(int(self.data_table.iloc[x]["index"])) for x in ix["ind"]
+                ]
+
+                if len(ant_lbls) > 5:
+                    ant_lbls = ant_lbls[:5]
+                    ant_txt = ",".join(ant_lbls) + ",..."
+                else:
+                    ant_txt = ",".join(ant_lbls)
+
+                self.annot.set_text(ant_txt)
+                self.annot.get_bbox_patch().set_facecolor("0.5")
+                self.annot.get_bbox_patch().set_alpha(0.4)
+
+                self.annot.set_visible(True)
+                self.fig.canvas.draw_idle()
+
+            else:
+                if vis:
+                    self.annot.set_visible(False)
+                    self.fig.canvas.draw_idle()
+
+    def on_click(self, event: Event) -> None:
+        if hasattr(event, "button") and event.button is MouseButton.LEFT:
+            self.fig.canvas.mpl_disconnect(self.handl_id)
+
+    def on_release(self, event: Event) -> None:
+        if hasattr(event, "button") and event.button is MouseButton.LEFT:
+            self.handl_id = self.fig.canvas.mpl_connect(
+                "motion_notify_event", self.hover_points
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = add_args(parser).parse_args()
+    main(args)

--- a/cryodrgn/dataset.py
+++ b/cryodrgn/dataset.py
@@ -92,7 +92,7 @@ class ImageDataset(data.Dataset):
 
         particles = self._process(self.src.images(index).to(self.device))
 
-        if isinstance(index, int):
+        if isinstance(index, (int, np.integer)):
             logger.debug(f"ImageDataset returning images at index ({index})")
         else:
             logger.debug(

--- a/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_filtering_template.ipynb
@@ -791,7 +791,9 @@
     "1. In the first cell, select points with the lasso tool. The table widget is dynamically updated with the most recent selection's indices. \n",
     "2. Then once you've finalized your selection, **run the next cell** to save the particle indices for downstream analysis/viz.\n",
     "\n",
-    "(Double click to clear selection)"
+    "(Double click to clear selection)\n",
+    "\n",
+    "You can also use our interactive command line tool `cryodrgn filter $WORKDIR` for selecting particles."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "torch>=1.0.0",
     "pandas<2",
-    "numpy",
+    "numpy<1.23",
     "matplotlib<3.7",
     "pyyaml",
     "scipy>=1.3.1",


### PR DESCRIPTION
We have introduced a number of small fixes and features since our last release `v3.0.1-beta`:

- making `cryodrgn analyze` produce a plot of the learning curve (#304)
- adding cell in cryoDRGN_filtering jupyter notebook returned by `cryodrgn analyze` for filtering by UMAP/PC values (#313)
- creating a new interactive command-line interface `cryodrgn filter` as an alternative to the buggy interface in the Jupyter filtering notebook (#323)
- fixing bugs with deprecated signatures in plotting functions (#322) and `numpy` dependency versioning (#318)
- option for automatically generating half-maps in `backproject_voxel` (#329)
- default to automatically finding and updating A/px values in `analyze` and `downsample` (#325)