### PR TITLE
v3.4.2: AMP for ab-initio reconstruction; faster pose parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ For any feedback, questions, or bugs, please file a Github issue or start a Gith
 
 ### New in Version 3.4.x
 * [NEW] `cryodrgn plot_classes` for analysis visualizations colored by a given set of class labels
-* support for RELION 3.1 .star files with separate optics tables
-* support for np.float16 number formats used in RELION .mrcs outputs
+* implementing [automatic mixed-precision training](https://pytorch.org/docs/stable/amp.html)
+  for ab-initio reconstruction for 2-4x speedup
+* support for RELION 3.1 .star files with separate optics tables, np.float16 number formats used in RELION .mrcs outputs
 * `cryodrgn backproject_voxel` produces cryoSPARC-style FSC curve plots with phase-randomization correction of
   automatically generated tight masks
 * `cryodrgn downsample` can create a new .star or .txt image stack from the corresponding stack format instead of

--- a/cryodrgn/commands/analyze.py
+++ b/cryodrgn/commands/analyze.py
@@ -28,7 +28,7 @@ from cryodrgn import analysis, utils, config
 logger = logging.getLogger(__name__)
 
 
-def add_args(parser):
+def add_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "workdir", type=os.path.abspath, help="Directory with cryoDRGN results"
     )
@@ -402,7 +402,8 @@ class VolumeGenerator:
         analysis.gen_volumes(self.weights, self.config, zfile, outdir, **self.vol_args)
 
 
-def main(args):
+def main(args: argparse.Namespace) -> None:
+    matplotlib.use("Agg")  # non-interactive backend
     t1 = dt.now()
     E = args.epoch
     workdir = args.workdir
@@ -527,10 +528,3 @@ def main(args):
             nbformat.write(filter_ntbook, f)
 
     logger.info(f"Finished in {dt.now() - t1}")
-
-
-if __name__ == "__main__":
-    matplotlib.use("Agg")  # non-interactive backend
-    parser = argparse.ArgumentParser(description=__doc__)
-    add_args(parser)
-    main(parser.parse_args())

--- a/cryodrgn/commands/analyze_landscape_full.py
+++ b/cryodrgn/commands/analyze_landscape_full.py
@@ -11,19 +11,20 @@ $ cryodrgn analyze_landscape_full 005_train-vae/ 39 -N 4000 -d 256
 """
 import argparse
 import os
-import os.path
 import pprint
 import shutil
 from datetime import datetime as dt
 import logging
+import nbformat
+
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.utils.data.dataloader import default_collate
-import torch.optim as optim
 from sklearn.model_selection import train_test_split
+from torch.utils.data.dataloader import default_collate
 from torch.utils.data import Dataset, DataLoader
+
 import cryodrgn
 from cryodrgn import config, utils
 from cryodrgn.models import HetOnlyVAE, ResidLinearMLP
@@ -63,6 +64,7 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     group = parser.add_argument_group("Volume generation arguments")
     group.add_argument(
         "-N",
+        "--training-volumes",
         type=int,
         default=10000,
         help="Number of training volumes to generate (default: %(default)s)",
@@ -178,10 +180,12 @@ def generate_and_map_volumes(
     zfile, cfg, weights, mask_mrc, pca_obj_pkl, landscape_dir, outdir, args
 ):
     # Sample z
-    logger.info(f"Sampling {args.N} particles from {zfile}")
+    logger.info(f"Sampling {args.training_volumes} particles from {zfile}")
     np.random.seed(args.seed)
     z_all = utils.load_pkl(zfile)
-    ind = np.array(sorted(np.random.choice(len(z_all), args.N, replace=False)))  # type: ignore
+    ind = np.array(
+        sorted(np.random.choice(len(z_all), args.training_volumes, replace=False))
+    )  # type: ignore
     z_sample = z_all[ind]
     utils.save_pkl(z_sample, f"{outdir}/z.sampled.pkl")
     utils.save_pkl(ind, f"{outdir}/ind.sampled.pkl")
@@ -223,7 +227,7 @@ def generate_and_map_volumes(
     t1 = dt.now()
     embeddings = []
     for i, zz in enumerate(z):
-        if i % 100 == 0:
+        if i % 1 == 0:
             logger.info(i)
 
         if args.downsample:
@@ -250,7 +254,7 @@ def generate_and_map_volumes(
     embeddings = np.array(embeddings).reshape(len(z), -1).astype(np.float32)
 
     td = dt.now() - t1
-    logger.info(f"Finished generating {args.N} volumes in {td}")
+    logger.info(f"Finished generating {args.training_volumes} volumes in {td}")
 
     return z, embeddings
 
@@ -286,7 +290,7 @@ def train_model(x, y, outdir, zfile, args):
         device
     )
     logger.info(model)
-    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
     # Train
     for epoch in range(1, args.epochs + 1):
@@ -312,6 +316,7 @@ def train_model(x, y, outdir, zfile, args):
 def main(args: argparse.Namespace) -> None:
     t1 = dt.now()
     logger.info(args)
+
     E = args.epoch
     workdir = args.workdir
     zfile = f"{workdir}/z.{E}.pkl"
@@ -334,6 +339,17 @@ def main(args: argparse.Namespace) -> None:
     assert os.path.exists(
         pca_obj_pkl
     ), f"{pca_obj_pkl} missing. Did you run cryodrgn analyze_landscape?"
+
+    kmeans_folder = [
+        p for p in os.listdir(landscape_dir) if p.startswith("clustering_L2_")
+    ]
+    if len(kmeans_folder) == 0:
+        raise RuntimeError(
+            "No clustering folders `clustering_L2_` found. "
+            "Did you run cryodrgn analyze_landscape?"
+        )
+    kmeans_folder = kmeans_folder[0]
+    link_method, kmeans_K = kmeans_folder.split("_")[-2:]
 
     logger.info(f"Saving results to {outdir}")
     if not os.path.exists(outdir):
@@ -361,13 +377,35 @@ def main(args: argparse.Namespace) -> None:
     utils.save_pkl(embeddings_all, f"{outdir}/vol_pca_all.pkl")
 
     # Copy viz notebook
-    out_ipynb = f"{landscape_dir}/cryoDRGN_analyze_landscape.ipynb"
+    out_ipynb = os.path.join(landscape_dir, "cryoDRGN_analyze_landscape.ipynb")
     if not os.path.exists(out_ipynb):
         logger.info("Creating jupyter notebook...")
-        ipynb = f"{cryodrgn._ROOT}/templates/cryoDRGN_analyze_landscape_template.ipynb"
+        ipynb = os.path.join(
+            cryodrgn._ROOT, "templates", "cryoDRGN_analyze_landscape_template.ipynb"
+        )
         shutil.copyfile(ipynb, out_ipynb)
     else:
         logger.info(f"{out_ipynb} already exists. Skipping")
+
+    # Lazily look at the beginning of the notebook for the epoch number to update
+    with open(out_ipynb, "r") as f:
+        filter_ntbook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
+
+    for cell in filter_ntbook["cells"]:
+        cell["source"] = cell["source"].replace("EPOCH = None", f"EPOCH = {args.epoch}")
+        cell["source"] = cell["source"].replace(
+            "WORKDIR = None", f'WORKDIR = "{args.workdir}"'
+        )
+        cell["source"] = cell["source"].replace(
+            "K = None", f"K = {args.training_volumes}"
+        )
+        cell["source"] = cell["source"].replace("M = None", f"M = {kmeans_K}")
+        cell["source"] = cell["source"].replace(
+            "linkage = None", f'linkage = "{link_method}"'
+        )
+
+    with open(out_ipynb, "w") as f:
+        nbformat.write(filter_ntbook, f)
 
     logger.info(out_ipynb)
     logger.info(f"Finished in {dt.now()-t1}")

--- a/cryodrgn/commands/analyze_landscape_full.py
+++ b/cryodrgn/commands/analyze_landscape_full.py
@@ -216,7 +216,8 @@ def generate_and_map_volumes(
 
     # Load model weights
     logger.info("Loading weights from {}".format(weights))
-    model, lattice = HetOnlyVAE.load(cfg, weights)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, lattice = HetOnlyVAE.load(cfg, weights, device)
     model.eval()
 
     # Set z
@@ -252,7 +253,6 @@ def generate_and_map_volumes(
         )
 
     embeddings = np.array(embeddings).reshape(len(z), -1).astype(np.float32)
-
     td = dt.now() - t1
     logger.info(f"Finished generating {args.training_volumes} volumes in {td}")
 

--- a/cryodrgn/commands/analyze_landscape_full.py
+++ b/cryodrgn/commands/analyze_landscape_full.py
@@ -241,7 +241,7 @@ def generate_and_map_volumes(
             )
 
         if args.flip:
-            vol = vol[::-1]
+            vol = vol.flip([0])
 
         embeddings.append(
             pca.transform(vol.cpu()[torch.tensor(mask).bool()].reshape(1, -1))

--- a/cryodrgn/commands/parse_pose_star.py
+++ b/cryodrgn/commands/parse_pose_star.py
@@ -71,7 +71,7 @@ def main(args: argparse.Namespace) -> None:
     logger.info("Euler angles (Rot, Tilt, Psi):")
     logger.info(euler[0])
     logger.info("Converting to rotation matrix:")
-    rot = np.asarray([utils.R_from_relion(*x) for x in euler])
+    rot = utils.R_from_relion(euler)
 
     logger.info(rot[0])
 

--- a/cryodrgn/source.py
+++ b/cryodrgn/source.py
@@ -33,13 +33,13 @@ Example usage
 import os.path
 from collections.abc import Iterable
 from concurrent import futures
+from copy import copy
 import numpy as np
 import pandas as pd
 from typing import List, Iterator, Optional, Union, Callable
 import logging
 import torch
-
-from cryodrgn.mrcfile import MRCHeader, write_mrc, get_mrc_header, fix_mrc_header
+from cryodrgn.mrcfile import MRCHeader, write_mrc, fix_mrc_header
 from cryodrgn.starfile import parse_star, Starfile
 
 logger = logging.getLogger(__name__)
@@ -231,12 +231,28 @@ class ImageSource:
         require_contiguous: bool = False,
         as_numpy: bool = False,
     ) -> Union[np.ndarray, torch.Tensor]:
+        """Retrieve the image data contained in this stack, or a subset thereof.
+
+        Arguments
+        ---------
+        indices:     The subset of images we want to return.
+        require_contiguous:
+            Whether the method should throw an error if image retrieval will entail
+            non-contiguous disk access. Callers can employ this if they insist on
+            efficient loading and choose to throw an error instead of falling back
+            on inefficient slower loading.
+        as_numpy:    Cast image data to a numpy array (instead of PyTorch tensor).
+
+        Returns
+        -------
+        images: Image data at specified indices.
+
+        """
         indices = self._convert_to_ndarray(indices)
 
         if self.lazy:
             # Convert incoming caller indices to indices that this ImageSource will use
-            if self.indices is not None:
-                indices = np.array(self.indices[indices])
+            indices = np.array(self.indices[indices])
             images = self._images(indices, require_contiguous=require_contiguous)
         else:
             images = self.data[indices, ...]  # cached data when not using lazy mode
@@ -253,25 +269,13 @@ class ImageSource:
     def _images(
         self, indices: np.ndarray, require_contiguous: bool = False
     ) -> np.ndarray:
-        """Base method for returning images at specified indices.
-
-        Arguments
-        ---------
-        indices (np.array): The subset of images we want to return.
-        require_contiguous (bool)
-            Whether the method should throw an error if image retrieval will entail
-            non-contiguous disk access. Callers can employ this if they insist on
-            efficient loading and choose to throw an error instead of falling back
-            on inefficient slower loading.
-        Returns
-        -------
-        Images (np.array) at specified indices.
-
-        """
+        """Retrieve images at specified indices from this stack's files."""
         raise NotImplementedError("Subclasses of `ImageSource` must implement this!")
 
     def chunks(
-        self, chunksize: int = 1000
+        self,
+        chunksize: int = 1000,
+        indices: Optional[np.ndarray] = None,
     ) -> Iterable[tuple[np.ndarray, torch.Tensor]]:
         """A generator that returns images in chunks of size `chunksize`.
 
@@ -279,9 +283,11 @@ class ImageSource:
             A 2-tuple of (<indices>, <torch.Tensor>).
 
         """
-        for i in range(0, self.n, chunksize):
-            indices = np.arange(i, min(self.n, i + chunksize))
-            yield indices, self.images(indices)
+        use_indices = copy(self.indices) if indices is None else np.array(indices)
+        for i in range(0, len(use_indices), chunksize):
+            indx = use_indices[np.arange(i, min(len(use_indices), i + chunksize))]
+
+            yield indx, self.images(indx)
 
     @property
     def apix(self) -> Union[None, float, np.ndarray]:
@@ -292,18 +298,21 @@ class ImageSource:
         self,
         output_file: str,
         header: Optional[MRCHeader] = None,
+        indices: Optional[np.ndarray] = None,
         transform_fn: Optional[Callable] = None,
         chunksize: Optional[int] = None,
     ) -> None:
         """Save this source's data to a .mrc file, using chunking if necessary."""
         if header is None and hasattr(self, "header"):
             header = self.header
+        if indices is None:
+            indices = np.arange(self.n)
 
         if chunksize is None:
             header_args = {"Apix": self.apix or 1.0} if header is None else dict()
             write_mrc(
                 output_file,
-                self.images(),
+                self.images(indices),
                 header=header,
                 transform_fn=transform_fn,
                 **header_args,
@@ -311,7 +320,12 @@ class ImageSource:
 
         else:
             if header is None:
-                header = get_mrc_header(self.images())
+                header = MRCHeader.make_default_header(
+                    nz=len(indices),
+                    ny=self.D,
+                    nx=self.D,
+                    dtype=self.dtype,
+                )
             else:
                 header = fix_mrc_header(header=header)
 
@@ -319,11 +333,11 @@ class ImageSource:
             with open(output_file, "wb") as f:
                 header.write(f)
 
-                for i, (indices, chunk) in enumerate(self.chunks(chunksize=chunksize)):
+                for i, (indx, chunk) in enumerate(self.chunks(chunksize, indices)):
                     logger.debug(f"Processing chunk {i}")
 
                     if transform_fn is not None:
-                        chunk = transform_fn(chunk, indices)
+                        chunk = transform_fn(chunk, indx)
                     if isinstance(chunk, torch.Tensor):
                         chunk = np.array(chunk.cpu()).astype(new_dtype)
 

--- a/cryodrgn/source.py
+++ b/cryodrgn/source.py
@@ -33,7 +33,6 @@ Example usage
 import os.path
 from collections.abc import Iterable
 from concurrent import futures
-from copy import copy
 import numpy as np
 import pandas as pd
 from typing import List, Iterator, Optional, Union, Callable
@@ -283,7 +282,7 @@ class ImageSource:
             A 2-tuple of (<indices>, <torch.Tensor>).
 
         """
-        use_indices = copy(self.indices) if indices is None else np.array(indices)
+        use_indices = np.arange(self.n) if indices is None else np.array(indices)
         for i in range(0, len(use_indices), chunksize):
             indx = use_indices[np.arange(i, min(len(use_indices), i + chunksize))]
 
@@ -325,6 +324,8 @@ class ImageSource:
                     ny=self.D,
                     nx=self.D,
                     dtype=self.dtype,
+                    is_vol=False,
+                    Apix=self.apix if self.apix is not None else 1.0,
                 )
             else:
                 header = fix_mrc_header(header=header)

--- a/cryodrgn/templates/cryoDRGN_analyze_landscape_template.ipynb
+++ b/cryodrgn/templates/cryoDRGN_analyze_landscape_template.ipynb
@@ -15,18 +15,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "import numpy as np\n",
     "import pickle\n",
     "import subprocess\n",
     "import os, sys\n",
     "\n",
-    "from cryodrgn import mrc\n",
+    "from cryodrgn.mrcfile import parse_mrc\n",
     "from cryodrgn import analysis\n",
     "from cryodrgn import utils\n",
     "from cryodrgn import dataset\n",
     "from cryodrgn import ctf\n",
-    "                \n",
+    " \n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "import plotly.graph_objs as go\n",
@@ -54,12 +53,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "EPOCH = None # change me if necessary!\n",
-    "WORKDIR = '..' # Directory with cryoDRGN outputs\n",
+    "EPOCH = None  # change me if necessary!\n",
+    "WORKDIR = None  # Directory with cryoDRGN outputs\n",
     "\n",
-    "K = 1000 # Number of sketched volumes\n",
-    "M = 10 # Number of clusters\n",
-    "linkage = 'average'"
+    "K = None  # Number of sketched volumes\n",
+    "M = None  # Number of clusters\n",
+    "linkage = None  # Linkage method used for clustering"
    ]
   },
   {
@@ -101,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = mrc.parse_mrc(f'{landscape_dir}/mask.mrc')\n",
+    "mask = parse_mrc(f'{landscape_dir}/mask.mrc')\n",
     "mask = mask[0].astype(bool)\n",
     "print(f'{mask.sum()} out of {np.prod(mask.shape)} voxels included in mask')"
    ]
@@ -143,8 +142,8 @@
    "source": [
     "# Load volumes\n",
     "'''\n",
-    "volm, _ = mrc.parse_mrc(f'kmeans{K}/vol_mean.mrc')\n",
-    "vols = np.array([mrc.parse_mrc(f'kmeans{K}/vol_{i:03d}.mrc')[0][mask] for i in range(K)])\n",
+    "volm, _ = parse_mrc(f'kmeans{K}/vol_mean.mrc')\n",
+    "vols = np.array([parse_mrc(f'kmeans{K}/vol_{i:03d}.mrc')[0][mask] for i in range(K)])\n",
     "vols.shape\n",
     "vols[vols<0]=0\n",
     "'''"

--- a/cryodrgn/utils.py
+++ b/cryodrgn/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions shared between various cryoDRGN operations and commands."""
+
 from collections.abc import Hashable
 import functools
 import os
@@ -84,6 +86,17 @@ def save_yaml(data, out_yamlfile: str, mode: str = "w"):
         logger.warning(f"Warning: {out_yamlfile} already exists. Overwriting.")
     with open(out_yamlfile, mode) as f:
         yaml.dump(data, f)
+
+
+def create_basedir(out: str) -> None:
+    """Create the parent directory of a path if necessary."""
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+
+
+def warn_file_exists(out: str) -> None:
+    """Notify user if an output file or directory already exists."""
+    if os.path.exists(out):
+        logger.warning(f"Warning: {out} already exists. Overwriting.")
 
 
 def run_command(cmd: str) -> tuple[str, str]:

--- a/tests/test_reconstruct.py
+++ b/tests/test_reconstruct.py
@@ -127,8 +127,8 @@ class TestFixedHetero:
         outdir = self.get_outdir(tmpdir_factory, particles, indices, poses, ctf)
         parser = argparse.ArgumentParser()
         analyze.add_args(parser)
-        args = parser.parse_args([outdir, str(epoch)])
-        analyze.main(args)
+        analyze.main(parser.parse_args([outdir, str(epoch)]))
+
         assert os.path.exists(os.path.join(outdir, f"analyze.{epoch}"))
 
     @pytest.mark.parametrize(
@@ -250,6 +250,26 @@ class TestFixedHetero:
         parser = argparse.ArgumentParser()
         analyze_landscape_full.add_args(parser)
         analyze_landscape_full.main(parser.parse_args(args))
+
+    @pytest.mark.parametrize("ctf", ["CTF-Test"], indirect=True)
+    def test_landscape_notebook(self, tmpdir_factory, particles, poses, ctf, indices):
+        """Execute the demo Jupyter notebooks produced by landscape analysis."""
+        outdir = self.get_outdir(tmpdir_factory, particles, indices, poses, ctf)
+        orig_cwd = os.path.abspath(os.getcwd())
+        os.chdir(os.path.join(outdir, "landscape.3"))
+        notebook_fl = "cryoDRGN_analyze_landscape.ipynb"
+        assert os.path.exists(notebook_fl)
+
+        with open(notebook_fl) as ff:
+            nb_in = nbformat.read(ff, nbformat.NO_CONVERT)
+
+        try:
+            ExecutePreprocessor(timeout=600, kernel_name="python3").preprocess(nb_in)
+        except CellExecutionError as e:
+            os.chdir(orig_cwd)
+            raise e
+
+        os.chdir(orig_cwd)
 
     @pytest.mark.parametrize(
         "ctf, seed, steps, points",
@@ -479,19 +499,24 @@ class TestAbinitHetero:
     def test_analyze(self, tmpdir_factory, particles, ctf, indices):
         """Produce standard analyses for a particular epoch."""
         outdir = self.get_outdir(tmpdir_factory, particles, indices, ctf)
-        args = analyze.add_args(argparse.ArgumentParser()).parse_args(
-            [
-                outdir,
-                "1",  # Epoch number to analyze - 0-indexed
-                "--pc",
-                "3",  # Number of principal component traversals to generate
-                "--ksample",
-                "10",  # Number of kmeans samples to generate
-                "--vol-start-index",
-                "1",
-            ]
+
+        parser = argparse.ArgumentParser()
+        analyze.add_args(parser)
+        analyze.main(
+            parser.parse_args(
+                [
+                    outdir,
+                    "1",  # Epoch number to analyze - 0-indexed
+                    "--pc",
+                    "3",  # Number of principal component traversals to generate
+                    "--ksample",
+                    "10",  # Number of kmeans samples to generate
+                    "--vol-start-index",
+                    "1",
+                ]
+            )
         )
-        analyze.main(args)
+
         assert os.path.exists(os.path.join(outdir, "analyze.1"))
 
     @pytest.mark.parametrize("nb_lbl", ["cryoDRGN_figures"])
@@ -751,19 +776,23 @@ class TestTiltFixedHetero:
         outdir = self.get_outdir(
             tmpdir_factory, particles, poses, ctf, indices, datadir
         )
-        args = analyze.add_args(argparse.ArgumentParser()).parse_args(
-            [
-                outdir,
-                "4",  # Epoch number to analyze - 0-indexed
-                "--pc",
-                "3",  # Number of principal component traversals to generate
-                "--ksample",
-                "2",  # Number of kmeans samples to generate
-                "--vol-start-index",
-                "1",
-            ]
+
+        parser = argparse.ArgumentParser()
+        analyze.add_args(parser)
+        analyze.main(
+            parser.parse_args(
+                [
+                    outdir,
+                    "4",  # Epoch number to analyze - 0-indexed
+                    "--pc",
+                    "3",  # Number of principal component traversals to generate
+                    "--ksample",
+                    "2",  # Number of kmeans samples to generate
+                    "--vol-start-index",
+                    "1",
+                ]
+            )
         )
-        analyze.main(args)
         assert os.path.exists(os.path.join(outdir, "analyze.4"))
 
     @pytest.mark.parametrize(

--- a/tests/test_reconstruct.py
+++ b/tests/test_reconstruct.py
@@ -167,13 +167,14 @@ class TestFixedHetero:
         os.chdir(orig_cwd)
 
     @pytest.mark.parametrize(
-        "ctf, downsample_dim",
+        "ctf, downsample_dim, flip_vol",
         [
-            (None, "16"),
-            ("CTF-Test", "16"),
+            (None, "16", False),
+            ("CTF-Test", "16", True),
             pytest.param(
                 "CTF-Test",
                 "64",
+                False,
                 marks=pytest.mark.xfail(
                     raises=ValueError, reason="box size > resolution"
                 ),
@@ -181,6 +182,7 @@ class TestFixedHetero:
             pytest.param(
                 "CTF-Test",
                 None,
+                False,
                 marks=pytest.mark.xfail(
                     raises=ValueError, reason="box size > resolution"
                 ),
@@ -189,7 +191,7 @@ class TestFixedHetero:
         indirect=["ctf"],
     )
     def test_landscape(
-        self, tmpdir_factory, particles, poses, ctf, indices, downsample_dim
+        self, tmpdir_factory, particles, poses, ctf, indices, downsample_dim, flip_vol
     ):
         outdir = self.get_outdir(tmpdir_factory, particles, indices, poses, ctf)
         args = [
@@ -204,19 +206,22 @@ class TestFixedHetero:
         ]
         if downsample_dim:
             args += ["--downsample", downsample_dim]
+        if flip_vol:
+            args += ["--flip"]
 
         parser = argparse.ArgumentParser()
         analyze_landscape.add_args(parser)
         analyze_landscape.main(parser.parse_args(args))
 
     @pytest.mark.parametrize(
-        "ctf, downsample_dim",
+        "ctf, downsample_dim, flip_vol",
         [
-            (None, "16"),
-            ("CTF-Test", "16"),
+            (None, "16", False),
+            ("CTF-Test", "16", True),
             pytest.param(
                 "CTF-Test",
                 "64",
+                False,
                 marks=pytest.mark.xfail(
                     raises=AssertionError, reason="box size > resolution"
                 ),
@@ -224,6 +229,7 @@ class TestFixedHetero:
             pytest.param(
                 "CTF-Test",
                 None,
+                False,
                 marks=pytest.mark.xfail(
                     raises=AssertionError, reason="box size > resolution"
                 ),
@@ -232,13 +238,14 @@ class TestFixedHetero:
         indirect=["ctf"],
     )
     def test_landscape_full(
-        self, tmpdir_factory, particles, poses, ctf, indices, downsample_dim
+        self, tmpdir_factory, particles, poses, ctf, indices, downsample_dim, flip_vol
     ):
         outdir = self.get_outdir(tmpdir_factory, particles, indices, poses, ctf)
-        parser = argparse.ArgumentParser()
         args = [outdir, "3", "-N", "10"]
         if downsample_dim is not None:
             args += ["--downsample", downsample_dim]
+        if flip_vol:
+            args += ["--flip"]
 
         parser = argparse.ArgumentParser()
         analyze_landscape_full.add_args(parser)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -199,10 +199,10 @@ def test_prespecified_indices_chunked(mrcs_data):
         os.path.join(pytest.DATADIR, "toy_projections.mrcs"),
         indices=np.array([0, 1, 5, 304]),
     )
-    assert src.shape == (4, 30, 30)  # Not (100, 30, 30)
+    assert src.shape == (4, 30, 30)  # Not (1000, 30, 30)
 
-    for i, (indices, chunk) in enumerate(src.chunks(chunksize=2)):
-        assert len(indices) == chunk.shape[0]
+    for i, (indx, chunk) in enumerate(src.chunks(chunksize=2)):
+        assert len(indx) == chunk.shape[0]
         if i == 0:
             assert torch.allclose(mrcs_data[np.array([0, 1]), :, :], chunk)
         elif i == 1:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from cryodrgn import utils
 def test_convert_from_relion_scipy():
     x = np.array([[-147.9485, 22.58999, 162.539]])
     r1 = utils.R_from_relion_scipy(x)[0]
-    r2 = utils.R_from_relion(*x[0])
+    r2 = utils.R_from_relion(x)[0]
     assert_array_almost_equal(r1, r2)
 
 


### PR DESCRIPTION
In this **patch release** we have extended the use of mixed precision training (as implemented in [torch.cuda.amp](https://pytorch.org/docs/stable/amp.html)), already the default for `train_nn` and `train_vae`, to the ab-initio reconstruction commands `abinit_homo` and `abinit_het`, resulting in observed speedups of 2-4x.

We have also vectorized rotation matrix computation in `parse_pose_star` for a ~100x speedup (#143), as well as fixed issues with `analyze_landscape_full` (#409, #413) and `downsample` (#412).